### PR TITLE
fix: remove Helm dependency

### DIFF
--- a/cert-manager/manifest.yaml
+++ b/cert-manager/manifest.yaml
@@ -5,6 +5,4 @@ version: v1.3.1
 maintainer: alex@openfaas.com
 description: cert-manager is a native Kubernetes certificate management controller
 url: https://cert-manager.io/docs/release-notes/release-notes-1.0/
-dependencies:
-  - Helm
 category: architecture


### PR DESCRIPTION
Helm hasn't been used since 62a2aac338dd263ef96086587c2fc619bf45c5de. The Helm dependency installs Helm 2, and Tiller, which is deprecated and a security issue.

If your pull request concerns an existing Marketplace application, please make sure you have:

* [ ] Notified the Maintainer of the application in this pull request so that they are aware of your proposal.
* [x] Outlined the changes you are proposing, and the reasons these are required (e.g. stability, compatibility with new versions of Kubernetes implementations, etc).
* [ ] Tested that the application works with the proposed updates applied (including a screenshot)
